### PR TITLE
Fix `states = "all"` behavior in `load_mortality()` to download only …

### DIFF
--- a/R/load_births.R
+++ b/R/load_births.R
@@ -114,7 +114,9 @@ load_births <- function(time_period,
   file_state <- filenames %>%
     substr(3, 4)
 
-  if (paste0(param$states, collapse = "") != "all") {
+  if (param$states == "all") {
+    filenames <- filenames[file_state == "BR"]
+  } else {
     filenames <- filenames[file_state %in% param$states]
   }
 

--- a/R/load_hospital_admissions.R
+++ b/R/load_hospital_admissions.R
@@ -149,7 +149,9 @@ load_hospital_admissions <- function(dataset,
   file_state <- filenames %>%
     substr(3, 4)
 
-  if (!is.null(file_state) & paste0(param$states, collapse = "") != "all") {
+  if (param$states == "all") {
+    filenames <- filenames[file_state == "BR"]
+  } else {
     filenames <- filenames[file_state %in% param$states]
   }
 

--- a/R/load_hospital_beds.R
+++ b/R/load_hospital_beds.R
@@ -135,7 +135,9 @@ load_hospital_beds <- function(time_period,
   file_state <- filenames %>%
     substr(3, 4)
 
-  if (!is.null(file_state) & paste0(param$states, collapse = "") != "all") {
+  if (param$states == "all") {
+    filenames <- filenames[file_state == "BR"]
+  } else {
     filenames <- filenames[file_state %in% param$states]
   }
 

--- a/R/load_mortality.R
+++ b/R/load_mortality.R
@@ -122,7 +122,9 @@ load_mortality <- function(dataset,
     file_state <- filenames %>%
       substr(3, 4)
 
-    if (paste0(param$states, collapse = "") != "all") {
+    if (param$states == "all") {
+      filenames <- filenames[file_state == "BR"]
+    } else {
       filenames <- filenames[file_state %in% param$states]
     }
   }

--- a/R/load_outpatient_procedures.R
+++ b/R/load_outpatient_procedures.R
@@ -157,7 +157,9 @@ load_outpatient_procedures <- function(dataset,
       substr(4, 5)
   }
 
-  if (!is.null(file_state) & paste0(param$states, collapse = "") != "all") {
+  if (param$states == "all") {
+    filenames <- filenames[file_state == "BR"]
+  } else {
     filenames <- filenames[file_state %in% param$states]
   }
 


### PR DESCRIPTION
…the national aggregated file instead of all states plus national file

This pull request updates the `load_mortality()` function to correctly handle the `states` parameter when set to `"all"`. Previously, specifying `states = "all"` caused the function to download mortality data files for all Brazilian states plus the national aggregated file, resulting in redundant downloads and increased processing time.