### PR TITLE
Correção download da função load_births

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -421,7 +421,7 @@ datasets_link <- function(source = NULL, dataset = NULL, url = FALSE) {
     "datasus", "datasus_cnes_ee", NA, "2007-2021", "State", "ftp://ftp.datasus.gov.br/dissemin/publicos/CNES/200508_/Dados/EE/$file_name$",
     "datasus", "datasus_cnes_ef", NA, "2005-2023", "State", "ftp://ftp.datasus.gov.br/dissemin/publicos/CNES/200508_/Dados/EF/$file_name$",
     "datasus", "datasus_cnes_gm", NA, "2005-2023", "State", "ftp://ftp.datasus.gov.br/dissemin/publicos/CNES/200508_/Dados/GM/$file_name$",
-    "datasus", "datasus_sinasc", NA, "1979-2025", "State", "ftp://ftp.datasus.gov.br/dissemin/publicos/SINASC/1996_/Dados/DNRES/$file_name$",
+    "datasus", "datasus_sinasc", NA, "1979-2023", "State", "ftp://ftp.datasus.gov.br/dissemin/publicos/SINASC/1996_/Dados/DNRES/$file_name$",
     "datasus", "datasus_po", NA, "1979-2025", "State", "ftp://ftp.datasus.gov.br/dissemin/publicos/PAINEL_ONCOLOGIA/DADOS/$file_name$",
     "datasus", "datasus_sih_rd", NA, "1979-2025", "State", "ftp://ftp.datasus.gov.br/dissemin/publicos/SIHSUS/200801_/Dados/$file_name$",
     "datasus", "datasus_sih_rj", NA, "1979-2025", "State", "ftp://ftp.datasus.gov.br/dissemin/publicos/SIHSUS/200801_/Dados/$file_name$",


### PR DESCRIPTION
Os dados da SINASC apenas estão disponíveis até 2023, antes aparentemente estava captando dados de 2024 e 2025, o que retornava um dataframe vazio. Agora, foi atualizado para evitar esse retorno vazio.