### PR TITLE
SIASUS dataset names problem

### DIFF
--- a/R/load_outpatient_procedures.R
+++ b/R/load_outpatient_procedures.R
@@ -88,10 +88,10 @@ load_outpatient_procedures <- function(dataset,
   param <- list()
 
   param$source <- "datasus"
-  param$dataset <- paste0("datasus_siasus_",dataset)
+  param$dataset <- dataset
   param$raw_data <- raw_data
   param$language <- language
-  param$suffix <- toupper(dataset)
+  param$suffix <- toupper(stringr::str_remove(dataset, pattern = "datasus_siasus_"))
 
   param$time_period <- time_period
   param$time_period_yy <- substr(time_period, 3, 4)


### PR DESCRIPTION
Ainda não resolvido! Quando estiver resolvido: this fixes #21 

Whenever we ran load_outpatient_procedures we got and error of unadmissable dataset. Following the "money", I identified this is generated in `check_params`. This function calls an object `supp_datasets` that contains all the admissable datasets - this is in turn generated in `download.R`. However, I have checked and everything until `supp_datasets` works fine - it is indeed pulling the correct dataset names. 

I manually created the object `param` which is defined between lines 88 and 99 in `load_outpatient_procedures.R` and download works fine (data cleaning is off, but that is a different problem). I am getting the following error: 
Error in if (!(param$dataset %in% supp_datasets)) { : argumento tem comprimento zero
