### PR TITLE
Melhoria na descrição

### DIFF
--- a/vignettes/vignette_load_hospital_admissions.Rmd
+++ b/vignettes/vignette_load_hospital_admissions.Rmd
@@ -30,50 +30,58 @@ The `load_hospital_admissions` function offers the following parameters:
         * `"rejected_aih_error"` – Rejected AIHs with specific error codes.
             Contains AIHs that were rejected due to inconsistencies found during processing. Each rejection includes a specific error code indicating the reason (e.g., invalid patient data, procedure incompatibilities).
 
-  2. **raw_data**: there are two options:
-      * `TRUE`: If you want the original DATASUS files in their segmented form.
-      * `FALSE`: if you want the treated version of the data.
-      
-  3. **time_period**: Specifies the years for which the data will be downloaded.
+  2. **time_period**: a numeric value or vector indicating the year(s) of the data to be downloaded.
+  For example, `2020` or `2015:2020`.
   
-  4. **states**: A vector of states by which to filter the data.
+  3. **states**: a string or vector of strings indicating the Brazilian state(s) for which the data should be downloaded.
+Use `"all"` to download data for the entire country. For specific states (valid only for the `general` dataset), use abbreviations like `"SP"` (São Paulo), `"RJ"` (Rio de Janeiro), or `c("SP", "RJ")`.
+  
+  4. **raw_data**: Logical, default is `FALSE`.
+      * `TRUE`: If TRUE, returns the raw data exactly as provided by DATASUS.
+      * `FALSE`: If FALSE (default), returns a cleaned and standardized version of the dataset.
 
-  5. **language**: You can choose between Portuguese `("pt")` and English `("eng")` for variable descriptions when `raw_data = FALSE`.
+  5. **language**: A string indicating the desired language of variable names and labels. Accepts `"eng"`                      (default) for English or `"pt"` for Portuguese (only when `raw_data = FALSE`).
   
 **Examples:**
 
 ```{r, eval = FALSE}
 library(datazoom.saude)
 
-# Download raw data for Reduced AIHs (AIHs Reduzida) – State of Amazonas, 2010.
+# Download raw data for Reduced AIHs (AIHs Reduzida) – All country, 2010.
 data_rd_raw <- load_hospital_admissions(
   dataset = "reduced_aih",
   time_period = 2010,
-  states = "AM",
-  raw_data = TRUE
+  states = "all",
+  raw_data = TRUE,
+  language = "eng"
 )
 
-# Download processed data for Rejected AIHs with Error Codes – State of Amazonas, 2010.
+# Download processed data for Rejected AIHs with Error Codes – State of Amazonas, 2010 to 2020.
+# Descriptions in Portuguese.
 data_er_processed <- load_hospital_admissions(
   dataset = "rejected_aih_error",
-  time_period = 2010,
+  time_period = 2010:2020,
   states = "AM",
-  raw_data = FALSE
+  raw_data = FALSE,
+  language = "pt"
 )
 
-# Download raw data for Professional Services – State of Acre, 2010.
+# Download raw data for Professional Services – States of Rio and São Paulo, 2022.
 data_sp_raw <- load_hospital_admissions(
   dataset = "professional_services",
-  time_period = 2010,
-  states = "AC",
-  raw_data = TRUE
+  time_period = 2022,
+  states = C("RJ","SP"),
+  raw_data = TRUE,
+  language = "eng"
 )
 
-# Download processed data for Professional Services – Federal District, 2010.
+# Download processed data for Professional Services – Federal District, 2020 to 2022.
+# Descriptions in Portuguese.
 data_sp_processed <- load_hospital_admissions(
   dataset = "professional_services",
-  time_period = 2010,
+  time_period = 2020:2022,
   states = "DF",
-  raw_data = FALSE
+  raw_data = FALSE,
+  language = "pt"
 )
 ```

--- a/vignettes/vignette_load_hospital_beds.Rmd
+++ b/vignettes/vignette_load_hospital_beds.Rmd
@@ -19,39 +19,48 @@ The `load_hospital_beds` function specifically focuses on the **CNES - LT (Beds)
 ***
 The `load_hospital_beds` function offers the following parameters:
 
-  1. **raw_data**: there are two options:
-      * `TRUE`: If you want the original DATASUS files in their segmented form.
-      * `FALSE`: if you want the treated version of the data.
-      
-  2. **time_period**: Specifies the years for which the data will be downloaded.
+  1. **time_period**: a numeric value or vector indicating the year(s) of the data to be downloaded.
+  For example, `2020` or `2015:2020`.
   
-  3. **states**: A vector of states by which to filter the data.
+  2. **states**: a string or vector of strings indicating the Brazilian state(s) for which the data should be downloaded.
+Use `"all"` to download data for the entire country. For specific states (valid only for the `general` dataset), use abbreviations like `"SP"` (São Paulo), `"RJ"` (Rio de Janeiro), or `c("SP", "RJ")`.
+  
+  3. **raw_data**: Logical, default is `FALSE`.
+      * `TRUE`: If TRUE, returns the raw data exactly as provided by DATASUS.
+      * `FALSE`: If FALSE (default), returns a cleaned and standardized version of the dataset.
+  
+  4. **keep_all**: A boolean choosing whether to aggregate the data by municipality, losing individual-level variables (`FALSE`) or to keep all original variables (`TRUE`).
+Only applies when `raw_data` is `FALSE`.
 
-  4. **language**: You can choose between Portuguese `("pt")` and English `("eng")` for variable descriptions when `raw_data = FALSE`.
+  5. **language**: A string indicating the desired language of variable names and labels. Accepts `"eng"`                      (default) for English or `"pt"` for Portuguese (only when `raw_data = FALSE`).
   
 **Examples:**
 
 ```{r, eval = FALSE}
 library(datazoom.saude)
 
-# Download treated data with the number of available beds in Amazonas (AM) and Pará (PA).
+# Download treated data - States of Amazonas and Pará, 2010.
 data_beds_full <- load_hospital_beds(
   time_period = 2010,
   states = c("AM", "PA"),
-  raw_data = FALSE
+  raw_data = FALSE,
+  language = "eng"
 )
 
-# Download treated data with the number of available beds in whole country.
+# Download treated data - Brrazil, 2010 to 2022.
+# Descriptions in Portuguese.
 data_beds_full <- load_hospital_beds(
-  time_period = 2010,
+  time_period = 2010:2022,
   states = "all",
-  raw_data = FALSE
+  raw_data = FALSE,
+  language = "pt"
 )
 
-# Download raw data for the number of hospital beds in 2015 for Rio de Janeiro.
+# Download raw data - States of Rio de Janeiro, 2015.
 data_beds_raw <- load_hospital_beds(
   time_period = 2015,
   states = "RJ",
-  raw_data = TRUE
+  raw_data = TRUE,
+  language = "eng"
 )
 ```

--- a/vignettes/vignette_load_mortality.Rmd
+++ b/vignettes/vignette_load_mortality.Rmd
@@ -32,27 +32,29 @@ The `load_mortality` function offers the following parameters:
         * `"maternal"` – Maternal mortality data.
             Contains a subset of `"general"` for deaths of women during or shortly after pregnancy/childbirth, detailing obstetric causes. Important for women's health.
 
-  2. **raw_data**: there are two options:
-      * `TRUE`: if you want the data as it is originally.
-      * `FALSE`: if you want the treated version of the data. Only effective for SIM-DO and subsets, SIH, and CNES-LT.
-  
-  3. **time_period**: a numeric value or vector indicating the year(s) of the data to be downloaded.
+  2. **time_period**: a numeric value or vector indicating the year(s) of the data to be downloaded.
   For example, `2020` or `2015:2020`.
   
-  4. **states**: a string or vector of strings indicating the Brazilian state(s) for which the data should be downloaded.
+  3. **states**: a string or vector of strings indicating the Brazilian state(s) for which the data should be downloaded.
 Use `"all"` to download data for the entire country. For specific states (valid only for the `general` dataset), use abbreviations like `"SP"` (São Paulo), `"RJ"` (Rio de Janeiro), or `c("SP", "RJ")`.
-
-  5. **language**: you can choose between Portuguese `("pt")` and English `("eng")`.
   
-  6. **keep_all**: A boolean choosing whether to aggregate the data by municipality, losing individual-level variables (`FALSE`) or to keep all original variables (`TRUE`).
+  4. **raw_data**: Logical, default is `FALSE`.
+      * `TRUE`: If TRUE, returns the raw data exactly as provided by DATASUS.
+      * `FALSE`: If FALSE (default), returns a cleaned and standardized version of the dataset.
+  
+  5. **keep_all**: A boolean choosing whether to aggregate the data by municipality, losing individual-level variables (`FALSE`) or to keep all original variables (`TRUE`).
 Only applies when `raw_data` is `FALSE`.
+
+  6. **language**: A string indicating the desired language of variable names and labels. Accepts `"eng"`                      (default) for English or `"pt"` for Portuguese (only when `raw_data = FALSE`).
+  
+  
   
 **Examples:**
 
 ```{r, eval = FALSE}
 library(datazoom.saude)
 
-# Download raw data for the year 2022 in the state of RJ for general mortality.
+# Download raw data for general mortality - State of Rio de Janeiro, 2022.
 raw_data_general_rj <- load_mortality(
   dataset = "general",
   time_period = 2022,
@@ -60,31 +62,52 @@ raw_data_general_rj <- load_mortality(
   raw_data = TRUE
 )
 
-# Download treated data with the number of deaths by cause in RJ, aggregated by municipality and year.
+# Download treated data for general mortality - States of Rio and São Paulo, 2022.
 trated_data_general_rj <- load_mortality(
   dataset = "general",
   time_period = 2022,
-  states = "RJ",
+  states = c("RJ", "SP"),
   raw_data = FALSE,
   keep_all = FALSE # Explicitly stating default behavior
 )
 
-# Download treated data for Maternal Deaths (`maternal`) for 2020,
-# for the entire country, with descriptions in Portuguese.
+# Download treated data for Maternal Deaths - Brazil, 2020 to 2022.
+# Descriptions in Portuguese.
 # Note: `maternal` does not provide separate files by state.
 data_maternal_pt <- load_mortality(
   dataset = "maternal",
-  time_period = 2020,
+  time_period = 2020:2022,
+  states = "all",
   raw_data = FALSE,
   language = "pt"
 )
 
-# Download treated data for Infant Deaths (`infant`) for 2017,
-# for all states, keeping all individual variables (not aggregated).
+# Download treated data for Infant Deaths - Brazil, 2017.
+# Keeping all individual variables (not aggregated).
 data_infant_full <- load_mortality(
   dataset = "infant",
   time_period = 2017,
+  states = "all",
   raw_data = FALSE,
-  keep_all = TRUE
+  keep_all = TRUE,
+  language = "eng"
+)
+  
+# Download treated data for Fetal Deaths - State of Amazonas, 2000.
+data_infant_full <- load_mortality(
+  dataset = "fetal",
+  time_period = 2000,
+  states = "AM", 
+  raw_data = FALSE,
+  language = "eng"
+)
+
+# Download treated data for External Causes Deaths - State of Acre, 2022.
+data_infant_full <- load_mortality(
+  dataset = "fetal",
+  time_period = 2022,
+  states = "AC", 
+  raw_data = FALSE,
+  language = "eng"
 )
 ```

--- a/vignettes/vignette_load_oncology_cases.Rmd
+++ b/vignettes/vignette_load_oncology_cases.Rmd
@@ -19,13 +19,14 @@ The `load_oncology_case` function downloads and organizes data from the **Oncolo
 ***
 The `load_oncology_case` function offers the following parameters:
 
-  1. **raw_data**: there are two options:
-      * `TRUE`: If you want the original DATASUS files in their segmented form.
-      * `FALSE`: if you want the treated version of the data.
+  1. **time_period**: a numeric value or vector indicating the year(s) of the data to be downloaded.
+  For example, `2020` or `2015:2020`.
   
-  2. **time_period**: Specifies the years for which the data will be downloaded.
+  2. **raw_data**: Logical, default is `FALSE`.
+      * `TRUE`: If TRUE, returns the raw data exactly as provided by DATASUS.
+      * `FALSE`: If FALSE (default), returns a cleaned and standardized version of the dataset.
 
-  3. **language**: You can choose between Portuguese `("pt")` and English `("eng")` for variable descriptions when `raw_data = FALSE`.
+  3. **language**: A string indicating the desired language of variable names and labels. Accepts `"eng"`                      (default) for English or `"pt"` for Portuguese (only when `raw_data = FALSE`).
   
 **Examples:**
 

--- a/vignettes/vignette_load_outpatient_procedures.Rmd
+++ b/vignettes/vignette_load_outpatient_procedures.Rmd
@@ -42,15 +42,17 @@ The `load_outpacient_procedures` function offers the following parameters:
         * `"siasus_sad"` – RAAS Home Care (RAAS Atenção Domiciliar)
             Focuses on outpatient care provided at patients' homes, often involving chronic condition management, palliative care, and multi-professional follow-ups.
 
-  2. **raw_data**: there are two options:
-      * `TRUE`: if you want the data as it is originally.
-      * `FALSE`: if you want the treated version of the data. Only effective for SIM-DO and subsets, SIH, and CNES-LT.
+  2. **time_period**: a numeric value or vector indicating the year(s) of the data to be downloaded.
+  For example, `2020` or `2015:2020`.
   
-  3. **time_period**: picks the years for which the data will be downloaded
+  3. **states**: a string or vector of strings indicating the Brazilian state(s) for which the data should be downloaded.
+Use `"all"` to download data for the entire country. For specific states (valid only for the `general` dataset), use abbreviations like `"SP"` (São Paulo), `"RJ"` (Rio de Janeiro), or `c("SP", "RJ")`.
   
-  4. **states**: a vector of states by which to filter the data. Only works for datasets whose data is provided in separate files by state.
+  4. **raw_data**: Logical, default is `FALSE`.
+      * `TRUE`: If TRUE, returns the raw data exactly as provided by DATASUS.
+      * `FALSE`: If FALSE (default), returns a cleaned and standardized version of the dataset.
 
-  5. **language**: you can choose between Portuguese `("pt")` and English `("eng")`
+  5. **language**: A string indicating the desired language of variable names and labels. Accepts `"eng"`                      (default) for English or `"pt"` for Portuguese (only when `raw_data = FALSE`).
   
 **Examples:**
 
@@ -61,34 +63,36 @@ library(datazoom.saude)
 teste_abo <- load_outpatient_procedures(
   dataset = "siasus_abo",
   time_period = 2012,
+  states = "AC",
   raw_data = FALSE,
-  language = "eng",
-  states = "AC"
+  language = "eng"
 )
 
 # Download processed data for Consolidated Outpatient Procedures (PA) – State of Acre, 2022.
+# Descriptions in Portuguese.
 teste_pa <- load_outpatient_procedures(
   dataset = "siasus_pa",
   time_period = 2022,
+  states = "AC",
   raw_data = FALSE,
-  language = "eng",
-  states = "AC"
+  language = "pt"
 )
 
-# Download raw data for High-Cost Medications (AM) for the year 2021 in Pernambuco (PE).
+# Download raw data for High-Cost Medications (AM) - State of Pernambuco, 2021.
 teste_am_raw <- load_outpatient_procedures(
   dataset = "siasus_am",
   time_period = 2021,
+  states = "PE",
   raw_data = TRUE,
-  states = "PE"
+  language = "eng"
 )
 
-# Download processed data for Psychosocial Care (PS) for the year 2022 in Acre (AC).
+# Download processed data for Psychosocial Care (PS) - State of Acre, 2022.
 teste_ps <- load_outpatient_procedures(
   dataset = "siasus_ps",
   time_period = 2022,
+  states = "AC",
   raw_data = FALSE,
-  language = "eng",
-  states = "AC"
+  language = "eng"
 )
 ```


### PR DESCRIPTION
- Mesma ordem dos argumentos da função no README e no exemplo.
- Exemplo contendo todos os argumentos.
- Formato dos estados (vetor "RJ", "SP", etc) e qual o período de tempo coberto por cada dataset no README.
- Explicitar no README para cada função quais os argumentos padrão (língua, raw_data, etc.).

Fixes #18 