### PR TITLE
Update vignette load_mortality

### DIFF
--- a/vignettes/vignette_load_mortality.Rmd
+++ b/vignettes/vignette_load_mortality.Rmd
@@ -21,22 +21,22 @@ The `load_mortality` function offers the following parameters:
   
   1. **dataset**: Specifies the SIM dataset to download:
       * SIM Datasets:
-        * `"general"` – Main Declarations of Death.
+        * `"general"` – Main Declarations of Death. (National dataset available — `states = "all"`)
             Contains records of all non-fetal Death Certificates (DO) in Brazil, including socio-demographic data, location, and causes of death (ICD-10). It's the base for general mortality analysis.
-        * `"fetal"` – Fetal mortality data.
-            Contains records of fetal deaths, with information on the mother, pregnancy, and causes of fetal death. It's essential for maternal and child health.
-        * `"external_causes"` – Mortality data from external causes.
+        * `"fetal"` – Fetal mortality data. (National dataset not available)
+        Contains records of fetal deaths, with information on the mother, pregnancy, and causes of fetal death. It's essential for maternal and child health.
+        * `"external_causes"` – Mortality data from external causes. (National dataset not available)
             Contains a subset of `"general"` focusing on deaths due to accidents, violence, and other unnatural causes. Used for safety and prevention studies.
-        * `"infant"` – Infant mortality data (children).
+        * `"infant"` – Infant mortality data (children). (National dataset not available)
             Contains a subset of `"general"` recording deaths of children under 1 year old, detailing causes and birth-related factors. Crucial for assessing child health.
-        * `"maternal"` – Maternal mortality data.
+        * `"maternal"` – Maternal mortality data. (National dataset not available)
             Contains a subset of `"general"` for deaths of women during or shortly after pregnancy/childbirth, detailing obstetric causes. Important for women's health.
 
   2. **time_period**: a numeric value or vector indicating the year(s) of the data to be downloaded.
   For example, `2020` or `2015:2020`.
   
-  3. **states**: a string or vector of strings indicating the Brazilian state(s) for which the data should be downloaded.
-Use `"all"` to download data for the entire country. For specific states (valid only for the `general` dataset), use abbreviations like `"SP"` (São Paulo), `"RJ"` (Rio de Janeiro), or `c("SP", "RJ")`.
+  3. **states**: (valid only for the `general` dataset) — a string or a vector of strings indicating the Brazilian state(s) for which the data should be downloaded.
+The default is `"all"`, which downloads data for the entire country. For specific states, use the official abbreviations such as `"SP"` (São Paulo), `"RJ"` (Rio de Janeiro), or `c("SP", "RJ")`.
   
   4. **raw_data**: Logical, default is `FALSE`.
       * `TRUE`: If TRUE, returns the raw data exactly as provided by DATASUS.


### PR DESCRIPTION
Identification of `states = "all"` as the default for the `general` dataset and discrimination of which datasets are at the national level.