### PR TITLE
Update MORTALITY

### DIFF
--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -63,6 +63,7 @@ load_dictionary <- function(dataset) {
 
       # Non-CID variables
 
+      "ano", "ano", "year", "Ano de referência", "Reference year", FALSE,
       "tipobito", "tipobito", "tipobito", "1: obito fetal\n2: obito nao fetal", "1: fetal death\n2: non-fetal death", FALSE,
       "dtobito", "dtobito", "dtobito", "Data do obito", "Date of death", FALSE,
       "horaobito", "horaobito", "horaobito", "Hora do falecimento", "Time of death", FALSE,
@@ -78,7 +79,7 @@ load_dictionary <- function(dataset) {
       "codbaires", "codbaires", "codbaires", "Codigo do Bairro de residencia", "Code of the neighborhood of residence", FALSE,
       "lococor", "lococor", "lococor", "Local de ocorrencia do obito:\n9: Ignorado\n1: Hospital\n2: Outro estab saude\n3: Domicilio\n4: Via Publica\n5: Outros", "Place of occurrence of death:\n9: Unknown\n1: Hospital\n2: Other health facility\n3: Home\n4: Public road\n5: Others", FALSE,
       "codestab", "codestab", "codestab", "Codigo do estabelecimento", "Establishment code", FALSE,
-      "codmunocor", "codmunocor", "codmunocor", "Municipio de ocorrencia do obito, conforme codigos IBGE", "Municipality of occurrence of death, according to IBGE codes", FALSE,
+      "codmunocor", "cod_munic", "munic_code", "Municipio de ocorrencia do obito, conforme codigos IBGE", "Municipality of occurrence of death, according to IBGE codes", FALSE,
       "codbaiocor", "codbaiocor", "codbaiocor", "Codigo do bairro de ocorrencia", "Code of the neighborhood of occurrence", FALSE,
       "idademae", "idademae", "idademae", "Idade da mae em anos", "Mother's age in years", FALSE,
       "escmae", "escmae", "escmae", "Escolaridade, Anos de estudo concluidos:\n1: Nenhuma\n2: 1 a 3 anos\n3: 4 a 7 anos\n4: 8 a 11 anos\n5: 12 e mais\n9: Ignorado", "Education, completed years of study:\n1: None\n2: 1 to 3 years\n3: 4 to 7 years\n4: 8 to 11 years\n5: 12 or more\n9: Unknown", FALSE,
@@ -101,7 +102,7 @@ load_dictionary <- function(dataset) {
       "linhac", "linhac", "linhac", "Linha C do atestado, conforme a Classificacao Internacional de Doenca (CID), 10a. Revisao", "Line C of the certificate, according to the International Classification of Diseases (ICD), 10th Revision", FALSE,
       "linhad", "linhad", "linhad", "Linha D do atestado, conforme a Classificacao Internacional de Doenca (CID), 10a. Revisao", "Line D of the certificate, according to the International Classification of Diseases (ICD), 10th Revision", FALSE,
       "linhaii", "linhaii", "linhaii", "Linha II do atestado, conforme a Classificacao Internacional de Doenca (CID), 10a. Revisao", "Line II of the certificate, according to the International Classification of Diseases (ICD), 10th Revision", FALSE,
-      "causabas", "causabas", "causabas", "Causa basica, conforme a Classificacao Internacional de Doenca (CID), 10a. Revisao", "Underlying cause, according to the International Classification of Diseases (ICD), 10th Revision", FALSE,
+      "causabas", "causa_de_morte", "cause_of_death", "Causa basica, conforme a Classificacao Internacional de Doenca (CID), 10a. Revisao", "Underlying cause, according to the International Classification of Diseases (ICD), 10th Revision", FALSE,
       "dtatestado", "dtatestado", "dtatestado", "Data do Atestado", "Date of the certificate", FALSE,
       "circobito", "circobito", "circobito", "Indica o tipo de acidente, se cabivel:\n9: Ignorado\n1: Acidente\n2: Suicidio\n3: Homicidio\n4: Outros", "Indicates the type of accident, if applicable:\n9: Unknown\n1: Accident\n2: Suicide\n3: Homicide\n4: Others", FALSE,
       "acidtrab", "acidtrab", "acidtrab", "Indica se foi acidente de trabalho, conforme a tabela:\n9: Ignorado\n1: Sim\n2: Nao", "Indicates whether it was a work-related accident, according to table:\n9: Unknown\n1: Yes\n2: No", FALSE,
@@ -114,7 +115,8 @@ load_dictionary <- function(dataset) {
       "fonteinv", "fonteinv", "fonteinv", "Fonte de investigacao:\n1 Comite de Morte Materna e/ou Infantil\n2 Visita domiciliar / Entrevista familia\n3 Estab Saude / Prontuario\n4 Relacion com outros bancos de dados\n5 S V O\n6 I M L\n7 Outra fonte\n8 Multiplas fontes\n9 Ignorado", "Source of investigation:\n1 Maternal and/or Child Death Committee\n2 Home visit / Family interview\n3 Health facility / Medical records\n4 Link with other databases\n5 Forensic Service (SVO)\n6 Forensic Institute (IML)\n7 Other source\n8 Multiple sources\n9 Unknown", FALSE,
       "dtrecebim", "dtrecebim", "dtrecebim", "Data de recebimento no nivel central, data da ultima atualizacao do registro", "Date received at the central level, date of last update of the record", FALSE,
       "ufinform", "ufinform", "ufinform", "Codigo da UF que informou o registro", "Code of the state (UF) that reported the record", FALSE,
-      "cb_pre", "cb_pre", "cb_pre", "Causa selecionada sem re-selecao (novo SCB)", "Cause selected without reselection (new SCB)", FALSE
+      "cb_pre", "cb_pre", "cb_pre", "Causa selecionada sem re-selecao (novo SCB)", "Cause selected without reselection (new SCB)", FALSE,
+      "num_de_mortes", "num_de_mortes", "num_of_deaths", "Número total de mortes", "Total number of deaths", FALSE
     )
   }
 

--- a/R/mortality.R
+++ b/R/mortality.R
@@ -255,7 +255,7 @@ load_mortality <- function(dataset,
   }
 
   # Renaming columns dynamically based on the chosen language
-  dic <- load_dictionary(param$dataset)
+  dic <- load_dictionary("datasus_sim")
 
   if (param$language == "pt") {
     names_map <- setNames(dic$name_pt, dic$var_code)
@@ -280,6 +280,12 @@ load_mortality <- function(dataset,
     # Adding a check to ensure that the 'code_muni_6' and 'causabas' columns exist
     if (("codmunocor" %in% names(dat)) && ("causabas" %in% names(dat))) {
 
+      rename_vars <- if (language == "pt") {
+        list(cod_munic = "codmunocor", causa_de_morte = "causabas", ano = "ano", num_de_mortes = "num_de_mortes")
+      } else {
+        list(munic_code = "codmunocor", cause_of_death = "causabas", year = "ano", num_of_deaths = "num_de_mortes")
+      }
+
       # Adding a new 'ano' column to group by
       dat <- dat %>%
         dplyr::mutate(
@@ -289,9 +295,10 @@ load_mortality <- function(dataset,
         dplyr::group_by(codmunocor, ano, causabas) %>%
         # Counting the number of deaths for each group
         dplyr::summarise(
-          count = dplyr::n(),
+          num_de_mortes = dplyr::n(),
           .groups = "drop" # Removes the grouping after summarization
-        )
+        ) %>%
+        rename(!!!rename_vars)
     } else {
       # If the required columns are not found, return a warning message and the non-aggregated data
       message("Warning: Columns 'codmunocor' or 'causabas' not found for aggregation. Returning non-aggregated data.")
@@ -309,12 +316,6 @@ load_mortality <- function(dataset,
     labels_map <- setNames(dic$label_eng, dic$name_eng)
   }
   labels_map <- labels_map[!is.na(labels_map)]
-
-  # Add new labels for aggregated columns
-  if (!param$keep_all) {
-    labels_map["count"] <- if (param$language == "pt") "Numero de obitos" else "Number of deaths"
-    labels_map["ano"] <- if (param$language == "pt") "Ano" else "Year"
-  }
 
   # Apply labels to the dataset
   current_names <- names(dat)

--- a/R/mortality.R
+++ b/R/mortality.R
@@ -189,6 +189,11 @@ load_mortality <- function(dataset,
 
   names(dat) <- filenames
 
+  dat <- dat %>%
+    purrr::imap(~ dplyr::mutate(.x, file_name = .y)) %>%
+    dplyr::bind_rows() %>%
+    janitor::clean_names()
+
   # Return Raw Data if requested
   if (param$raw_data) {
     return(dat)
@@ -197,11 +202,6 @@ load_mortality <- function(dataset,
   ########################
   ### Data Engineering ###
   ########################
-
-  dat <- dat %>%
-    purrr::imap(~ dplyr::mutate(.x, file_name = .y)) %>%
-    dplyr::bind_rows() %>%
-    janitor::clean_names()
 
   # Making sure all columns that will be processed exist before processing
   if ("codmunocor" %in% names(dat)) {
@@ -289,7 +289,7 @@ load_mortality <- function(dataset,
         dplyr::group_by(codmunocor, ano, causabas) %>%
         # Counting the number of deaths for each group
         dplyr::summarise(
-          count = n(),
+          count = dplyr::n(),
           .groups = "drop" # Removes the grouping after summarization
         )
     } else {

--- a/vignettes/MORTALITY.Rmd
+++ b/vignettes/MORTALITY.Rmd
@@ -21,22 +21,22 @@ The `load_mortality` function offers the following parameters:
   
   1. **dataset**: Specifies the SIM dataset to download:
       * SIM Datasets:
-        * `"general"` – Main Declarations of Death.
+        * `"general"` – Main Declarations of Death. (National dataset available — `states = "all"`)
             Contains records of all non-fetal Death Certificates (DO) in Brazil, including socio-demographic data, location, and causes of death (ICD-10). It's the base for general mortality analysis.
-        * `"fetal"` – Fetal mortality data.
-            Contains records of fetal deaths, with information on the mother, pregnancy, and causes of fetal death. It's essential for maternal and child health.
-        * `"external_causes"` – Mortality data from external causes.
+        * `"fetal"` – Fetal mortality data. (National dataset not available)
+        Contains records of fetal deaths, with information on the mother, pregnancy, and causes of fetal death. It's essential for maternal and child health.
+        * `"external_causes"` – Mortality data from external causes. (National dataset not available)
             Contains a subset of `"general"` focusing on deaths due to accidents, violence, and other unnatural causes. Used for safety and prevention studies.
-        * `"infant"` – Infant mortality data (children).
+        * `"infant"` – Infant mortality data (children). (National dataset not available)
             Contains a subset of `"general"` recording deaths of children under 1 year old, detailing causes and birth-related factors. Crucial for assessing child health.
-        * `"maternal"` – Maternal mortality data.
+        * `"maternal"` – Maternal mortality data. (National dataset not available)
             Contains a subset of `"general"` for deaths of women during or shortly after pregnancy/childbirth, detailing obstetric causes. Important for women's health.
 
   2. **time_period**: a numeric value or vector indicating the year(s) of the data to be downloaded.
   For example, `2020` or `2015:2020`.
   
-  3. **states**: a string or vector of strings indicating the Brazilian state(s) for which the data should be downloaded.
-Use `"all"` to download data for the entire country. For specific states (valid only for the `general` dataset), use abbreviations like `"SP"` (São Paulo), `"RJ"` (Rio de Janeiro), or `c("SP", "RJ")`.
+  3. **states**: (valid only for the `general` dataset) — a string or a vector of strings indicating the Brazilian state(s) for which the data should be downloaded.
+The default is `"all"`, which downloads data for the entire country. For specific states, use the official abbreviations such as `"SP"` (São Paulo), `"RJ"` (Rio de Janeiro), or `c("SP", "RJ")`.
   
   4. **raw_data**: Logical, default is `FALSE`.
       * `TRUE`: If TRUE, returns the raw data exactly as provided by DATASUS.


### PR DESCRIPTION
Identification of states = "all" as the default for the general dataset and discrimination of which datasets are at the national level and improved variable names when `raw_data = FALSE`.

Fix #32 